### PR TITLE
Use any version of six package

### DIFF
--- a/postgres_stats/aggregates.py
+++ b/postgres_stats/aggregates.py
@@ -54,7 +54,7 @@ class Percentile(Aggregate):
         else:
             extra['function'] = 'PERCENTILE_DISC'
 
-        if six.PY2:
-            super(Percentile, self).__init__(expression, percentiles=percentiles, **extra)
-        else:
+        if six.PY3:
             super().__init__(expression, percentiles=percentiles, **extra)
+        else:
+            super(Percentile, self).__init__(expression, percentiles=percentiles, **extra)

--- a/postgres_stats/functions.py
+++ b/postgres_stats/functions.py
@@ -100,9 +100,7 @@ class Extract(Func):
     template = "%(function)s(%(subfield)s FROM %(expressions)s)"
 
     def __init__(self, expression, subfield, **extra):
-        if six.PY2:
-            super(Extract, self).__init__(expression, subfield=subfield, **extra)
-        else:
+        if six.PY3:
             super().__init__(expression, subfield=subfield, **extra)
-
-
+        else:
+            super(Extract, self).__init__(expression, subfield=subfield, **extra)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Django>=1.8.6
 psycopg2>=2.6.1
-six==1.10.0
+six>=1.0.0b1


### PR DESCRIPTION
Use six.PY3 as it has been there from the begging (as six.PY2 has been released since version 1.4.0). So, this way, we are free from six version restriction in requirements.